### PR TITLE
Kache 3 fix maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <properties>
         <kotlin.version>1.6.10</kotlin.version>
         <dokka.version>1.6.10</dokka.version>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <mockito.inline.version>3.8.0</mockito.inline.version>
         <kotest.extensions>5.2.1</kotest.extensions>
@@ -121,6 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,17 @@
     </licenses>
 
     <properties>
-        <kotlin.version>1.4.32</kotlin.version>
-        <dokka.version>1.4.20</dokka.version>
+        <kotlin.version>1.6.10</kotlin.version>
+        <dokka.version>1.6.10</dokka.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
 
         <mockito.inline.version>3.8.0</mockito.inline.version>
-        <kotest.extensions>4.4.3</kotest.extensions>
+        <kotest.extensions>5.2.1</kotest.extensions>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
     </properties>
 
     <dependencies>
@@ -61,19 +61,19 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-runner-junit5-jvm</artifactId>
-            <version>4.4.3</version>
+            <version>${kotest.extensions}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-assertions-core-jvm</artifactId>
-            <version>4.4.3</version>
+            <version>${kotest.extensions}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-property-jvm</artifactId>
-            <version>4.4.3</version>
+            <version>${kotest.extensions}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>io.kotest</groupId>
-            <artifactId>kotest-extensions-spring-jvm</artifactId>
+            <artifactId>kotest-extensions-jvm</artifactId>
             <version>${kotest.extensions}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>13</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
             <groupId>io.kotest</groupId>
             <artifactId>kotest-extensions-spring-jvm</artifactId>
             <version>${kotest.extensions}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/Cache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/Cache.kt
@@ -9,7 +9,7 @@ import java.util.*
  * @param E is the value of the cache.
  * @property size is the current size of the cache.
  */
-interface Cache<T, E> {
+interface Cache<T: Any, E: Any> {
 
     val size: Int
 

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/Cache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/Cache.kt
@@ -9,7 +9,7 @@ import java.util.*
  * @param E is the value of the cache.
  * @property size is the current size of the cache.
  */
-interface Cache<T: Any, E: Any> {
+interface Cache<T, E: Any> {
 
     val size: Int
 

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/model/CustomTimeBasedValue.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/model/CustomTimeBasedValue.kt
@@ -9,7 +9,7 @@ import java.time.Duration
  * @property value the value to add
  * @property expirationTime the expiration time of the value
  */
-data class CustomTimeBasedValue<E>(
+data class CustomTimeBasedValue<E: Any>(
     val value: E,
     val expirationTime: Duration
 )

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/permanent/PermanentCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/permanent/PermanentCache.kt
@@ -5,7 +5,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 
-class PermanentCache<T, E>: Cache<T, E> {
+class PermanentCache<T: Any, E: Any>: Cache<T, E> {
 
     private val cacheMap: ConcurrentHashMap<T, E> = ConcurrentHashMap()
 
@@ -35,4 +35,4 @@ class PermanentCache<T, E>: Cache<T, E> {
     }
 }
 
-inline fun <reified T, reified E> permanentCache(): PermanentCache<T, E> = PermanentCache()
+inline fun <reified T: Any, reified E: Any> permanentCache(): PermanentCache<T, E> = PermanentCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/permanent/PermanentCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/permanent/PermanentCache.kt
@@ -5,7 +5,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 
-class PermanentCache<T: Any, E: Any>: Cache<T, E> {
+class PermanentCache<T, E: Any>: Cache<T, E> {
 
     private val cacheMap: ConcurrentHashMap<T, E> = ConcurrentHashMap()
 
@@ -35,4 +35,4 @@ class PermanentCache<T: Any, E: Any>: Cache<T, E> {
     }
 }
 
-inline fun <reified T: Any, reified E: Any> permanentCache(): PermanentCache<T, E> = PermanentCache()
+inline fun <reified T, reified E: Any> permanentCache(): PermanentCache<T, E> = PermanentCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/CustomTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/CustomTimeBasedCache.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
-open class CustomTimeBasedCache<T: Any, E: Any> (
+open class CustomTimeBasedCache<T, E: Any> (
     private var defaultExpiration: Duration
         ): TimeBasedCache<T, E> {
 
@@ -74,4 +74,4 @@ open class CustomTimeBasedCache<T: Any, E: Any> (
     }
 }
 
-inline fun <reified T: Any, reified E: Any> customTimeBasedCache(expirationTime: Duration): CustomTimeBasedCache<T, E> = CustomTimeBasedCache(expirationTime)
+inline fun <reified T, reified E: Any> customTimeBasedCache(expirationTime: Duration): CustomTimeBasedCache<T, E> = CustomTimeBasedCache(expirationTime)

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/CustomTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/CustomTimeBasedCache.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
-open class CustomTimeBasedCache<T, E> (
+open class CustomTimeBasedCache<T: Any, E: Any> (
     private var defaultExpiration: Duration
         ): TimeBasedCache<T, E> {
 
@@ -74,4 +74,4 @@ open class CustomTimeBasedCache<T, E> (
     }
 }
 
-inline fun <reified T, reified E> customTimeBasedCache(expirationTime: Duration): CustomTimeBasedCache<T, E> = CustomTimeBasedCache(expirationTime)
+inline fun <reified T: Any, reified E: Any> customTimeBasedCache(expirationTime: Duration): CustomTimeBasedCache<T, E> = CustomTimeBasedCache(expirationTime)

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/LongTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/LongTimeBasedCache.kt
@@ -3,9 +3,9 @@ package io.github.pavleprica.kotlin.cache.time.based
 /**
  * Short time based cache that will hold the cache for 60 minutes
  */
-class LongTimeBasedCache<T, E>: CustomTimeBasedCache<T, E>(ONE_HOUR) {
+class LongTimeBasedCache<T: Any, E: Any>: CustomTimeBasedCache<T, E>(ONE_HOUR) {
 
 
 }
 
-inline fun <reified T, reified E> longTimeBasedCache(): LongTimeBasedCache<T, E> = LongTimeBasedCache()
+inline fun <reified T: Any, reified E: Any> longTimeBasedCache(): LongTimeBasedCache<T, E> = LongTimeBasedCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/LongTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/LongTimeBasedCache.kt
@@ -3,9 +3,9 @@ package io.github.pavleprica.kotlin.cache.time.based
 /**
  * Short time based cache that will hold the cache for 60 minutes
  */
-class LongTimeBasedCache<T: Any, E: Any>: CustomTimeBasedCache<T, E>(ONE_HOUR) {
+class LongTimeBasedCache<T, E: Any>: CustomTimeBasedCache<T, E>(ONE_HOUR) {
 
 
 }
 
-inline fun <reified T: Any, reified E: Any> longTimeBasedCache(): LongTimeBasedCache<T, E> = LongTimeBasedCache()
+inline fun <reified T, reified E: Any> longTimeBasedCache(): LongTimeBasedCache<T, E> = LongTimeBasedCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/ShortTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/ShortTimeBasedCache.kt
@@ -3,8 +3,8 @@ package io.github.pavleprica.kotlin.cache.time.based
 /**
  * Short time based cache that will hold the cache for 1 minute
  */
-class ShortTimeBasedCache<T, E>: CustomTimeBasedCache<T, E>(ONE_MINUTE) {
+class ShortTimeBasedCache<T: Any, E: Any>: CustomTimeBasedCache<T, E>(ONE_MINUTE) {
 
 }
 
-inline fun <reified T, reified E> shortTimeBasedCache(): ShortTimeBasedCache<T, E> = ShortTimeBasedCache()
+inline fun <reified T: Any, reified E: Any> shortTimeBasedCache(): ShortTimeBasedCache<T, E> = ShortTimeBasedCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/ShortTimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/ShortTimeBasedCache.kt
@@ -3,8 +3,8 @@ package io.github.pavleprica.kotlin.cache.time.based
 /**
  * Short time based cache that will hold the cache for 1 minute
  */
-class ShortTimeBasedCache<T: Any, E: Any>: CustomTimeBasedCache<T, E>(ONE_MINUTE) {
+class ShortTimeBasedCache<T, E: Any>: CustomTimeBasedCache<T, E>(ONE_MINUTE) {
 
 }
 
-inline fun <reified T: Any, reified E: Any> shortTimeBasedCache(): ShortTimeBasedCache<T, E> = ShortTimeBasedCache()
+inline fun <reified T, reified E: Any> shortTimeBasedCache(): ShortTimeBasedCache<T, E> = ShortTimeBasedCache()

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/TimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/TimeBasedCache.kt
@@ -13,7 +13,7 @@ import java.time.Duration
  * @param E is the value of the cache.
  * @property defaultExpirationTime is the default value for setting the expiration time.
  */
-interface TimeBasedCache<T, E>: Cache<T, E> {
+interface TimeBasedCache<T: Any, E: Any>: Cache<T, E> {
 
     val defaultExpirationTime: Duration
 

--- a/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/TimeBasedCache.kt
+++ b/src/main/kotlin/io/github/pavleprica/kotlin/cache/time/based/TimeBasedCache.kt
@@ -13,7 +13,7 @@ import java.time.Duration
  * @param E is the value of the cache.
  * @property defaultExpirationTime is the default value for setting the expiration time.
  */
-interface TimeBasedCache<T: Any, E: Any>: Cache<T, E> {
+interface TimeBasedCache<T, E: Any>: Cache<T, E> {
 
     val defaultExpirationTime: Duration
 


### PR DESCRIPTION
- Fix dependencies
- Upgrade a number of dependencies
- Fix a Kotlin compiler warning that could lead to an error in future Kotlin version
- Downgrade Java version from 13 to 11 for increased compatibility

(Java8 would not work with a number of the tests as they are currently written).